### PR TITLE
Fix SelectMany for lists, tuples, and dicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 awkward>=0.12.17
+numpy
 qastle>=0.7
 uproot>=3.6.0

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,7 @@
 import ast
 
+import numpy as np
+
 import qastle
 
 from func_adl_uproot import ast_executor
@@ -12,11 +14,29 @@ def test_ast_executor_select_scalar_branch():
     assert ast_executor(python_ast).tolist() == [0, -1]
 
 
+def test_ast_executor_select_scalar_branch_list():
+    python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
+                     + ' lambda row: [row.int_branch, row.long_branch])')
+    python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
+    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
+    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+
+
+def test_ast_executor_select_scalar_branch_tuple():
+    python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
+                     + ' lambda row: (row.int_branch, row.long_branch))')
+    python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
+    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
+    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+
+
 def test_ast_executor_select_scalar_branch_dict():
     python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
-                     + " lambda row: {'int_branch': row.int_branch})")
+                     + " lambda row: {'int_branch': row.int_branch,"
+                     + " 'long_branch': row.long_branch})")
     python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
     assert ast_executor(python_ast)['int_branch'].tolist() == [0, -1]
+    assert ast_executor(python_ast)['long_branch'].tolist() == [0, -2]
 
 
 def test_ast_executor_where_scalar_branch():
@@ -41,8 +61,26 @@ def test_ast_executor_selectmany_vector_branch():
     assert ast_executor(python_ast).tolist() == [-1, 2, 3, 13]
 
 
+def test_ast_executor_selectmany_vector_branch_list():
+    python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
+                     + ' lambda row: [row.int_vector_branch, row.float_vector_branch])')
+    python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
+    assert ast_executor(python_ast)['0'].tolist() == [-1, 2, 3, 13]
+    assert np.allclose(ast_executor(python_ast)['1'], [-7.7, 8.8, 9.9, 15.15])
+
+
+def test_ast_executor_selectmany_vector_branch_tuple():
+    python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
+                     + ' lambda row: (row.int_vector_branch, row.float_vector_branch))')
+    python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
+    assert ast_executor(python_ast)['0'].tolist() == [-1, 2, 3, 13]
+    assert np.allclose(ast_executor(python_ast)['1'], [-7.7, 8.8, 9.9, 15.15])
+
+
 def test_ast_executor_selectmany_vector_branch_dict():
     python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
-                     + " lambda row: {'int_vector_branch': row.int_vector_branch})")
+                     + " lambda row: {'int_vector_branch': row.int_vector_branch,"
+                     + " 'float_vector_branch': row.float_vector_branch})")
     python_ast = qastle.insert_linq_nodes(ast.parse(python_source))
     assert ast_executor(python_ast)['int_vector_branch'].tolist() == [-1, 2, 3, 13]
+    assert np.allclose(ast_executor(python_ast)['float_vector_branch'], [-7.7, 8.8, 9.9, 15.15])

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -28,14 +28,6 @@ def assert_modified_source(initial_source, final_source):
     assert rep == final_source
 
 
-def assert_identical_sources_after_translation(source_1, source_2):
-    python_ast_1 = qastle.insert_linq_nodes(ast.parse(source_1))
-    python_ast_2 = qastle.insert_linq_nodes(ast.parse(source_2))
-    rep_1 = python_ast_to_python_source(python_ast_1)
-    rep_2 = python_ast_to_python_source(python_ast_2)
-    assert rep_1 == rep_2
-
-
 def test_literals():
     assert_identical_literal('')
     assert_identical_literal('a')
@@ -150,8 +142,9 @@ def test_select():
 
 
 def test_selectmany():
-    assert_identical_sources_after_translation('SelectMany(uproot, lambda row: row)',
-                                               '(lambda row: row)(uproot).flatten()')
+    assert_modified_source('SelectMany(uproot, lambda row: row)',
+                           "(lambda row: (row.flatten if hasattr(row, 'flatten') "
+                             + "else row['flatten'])())(uproot)")
 
 
 def test_where():

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -144,7 +144,7 @@ def test_select():
 def test_selectmany():
     assert_modified_source('SelectMany(uproot, lambda row: row)',
                            "(lambda row: (row.flatten if hasattr(row, 'flatten') "
-                             + "else row['flatten'])())(uproot)")
+                           + "else row['flatten'])())(uproot)")
 
 
 def test_where():


### PR DESCRIPTION
`awkward.Table` can't be flattened directly, so flatten each column separately.

Resolves #25.