### PR TITLE
Reject awkward==1.0.1, CI improvements

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,9 +2,10 @@ name: Python package
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
@@ -14,9 +15,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -e .[test]
     - name: Lint with flake8
       run: |
         flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-awkward>=1
-numpy
-qastle>=0.10
-uproot>=4

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(name='func_adl_uproot',
                                    'numpy',
                                    'qastle>=0.10',
                                    'uproot>=4'],
+                 extras_require={'test': ['flake8', 'pytest', 'pytest-cov']},
                  author='Mason Proffitt',
                  author_email='masonlp@uw.edu',
                  url='https://github.com/iris-hep/func_adl_uproot')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(name='func_adl_uproot',
                  packages=setuptools.find_packages(exclude=['tests']),
                  python_requires=('>=2.7, '
                                   '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <3.10'),
-                 install_requires=['awkward>=1',
+                 install_requires=['awkward>=1, !=1.0.1',
                                    'numpy',
                                    'qastle>=0.10',
                                    'uproot>=4'],


### PR DESCRIPTION
- Testing requirements are now pulled in through setup.py
- Eliminates requirements.txt
- Rejects awkward==1.0.1 (completely broken for use within this package)
- Adds testing for Windows and MacOS