### PR TITLE
Transformer simplifications

### DIFF
--- a/func_adl_uproot/transformer.py
+++ b/func_adl_uproot/transformer.py
@@ -110,7 +110,7 @@ class PythonSourceGeneratorTransformer(ast.NodeTransformer):
         return node
 
     def resolve_id(self, id):
-        if id in dir(__builtins__) or id in self._id_scopes:
+        if id in __builtins__ or id in self._id_scopes:
             return id
         else:
             raise NameError('Unknown id: ' + id)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -47,7 +47,14 @@ def test_ast_executor_list_without_treename():
                                                'bool_branch']
 
 
-def test_ast_executor_select_scalar_branch():
+def test_ast_executor_select_scalar_branch_subscript():
+    python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
+                     + " lambda row: row['int_branch'])")
+    python_ast = ast.parse(python_source)
+    assert ast_executor(python_ast).tolist() == [0, -1]
+
+
+def test_ast_executor_select_scalar_branch_attribute():
     python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
                      + ' lambda row: row.int_branch)')
     python_ast = ast.parse(python_source)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -58,16 +58,16 @@ def test_ast_executor_select_scalar_branch_list():
     python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
                      + ' lambda row: [row.int_branch, row.long_branch])')
     python_ast = ast.parse(python_source)
-    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
-    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+    assert ast_executor(python_ast)[0].tolist() == [0, -1]
+    assert ast_executor(python_ast)[1].tolist() == [0, -2]
 
 
 def test_ast_executor_select_scalar_branch_tuple():
     python_source = ("Select(EventDataset('tests/scalars_tree_file.root', 'tree'),"
                      + ' lambda row: (row.int_branch, row.long_branch))')
     python_ast = ast.parse(python_source)
-    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
-    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+    assert ast_executor(python_ast)[0].tolist() == [0, -1]
+    assert ast_executor(python_ast)[1].tolist() == [0, -2]
 
 
 def test_ast_executor_select_scalar_branch_dict():
@@ -83,8 +83,8 @@ def test_ast_executor_select_of_select_scalar_branch_list():
                      + ' lambda row: [row.int_branch, row.long_branch])'
                      + '.Select(lambda row: [row[0], row[1]])')
     python_ast = ast.parse(python_source)
-    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
-    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+    assert ast_executor(python_ast)[0].tolist() == [0, -1]
+    assert ast_executor(python_ast)[1].tolist() == [0, -2]
 
 
 def test_ast_executor_select_of_select_scalar_branch_tuple():
@@ -92,8 +92,8 @@ def test_ast_executor_select_of_select_scalar_branch_tuple():
                      + ' lambda row: (row.int_branch, row.long_branch))'
                      + '.Select(lambda row: (row[0], row[1]))')
     python_ast = ast.parse(python_source)
-    assert ast_executor(python_ast)['0'].tolist() == [0, -1]
-    assert ast_executor(python_ast)['1'].tolist() == [0, -2]
+    assert ast_executor(python_ast)[0].tolist() == [0, -1]
+    assert ast_executor(python_ast)[1].tolist() == [0, -2]
 
 
 def test_ast_executor_select_of_select_scalar_branch_dict():
@@ -129,7 +129,7 @@ def test_ast_executor_selectmany_vector_branch():
 
 def test_ast_executor_selectmany_vector_branch_list():
     python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
-                     + ' lambda row: [row.int_vector_branch, row.float_vector_branch])')
+                     + ' lambda row: Zip([row.int_vector_branch, row.float_vector_branch]))')
     python_ast = ast.parse(python_source)
     assert ast_executor(python_ast)['0'].tolist() == [-1, 2, 3, 13]
     assert np.allclose(ast_executor(python_ast)['1'].tolist(), [-7.7, 8.8, 9.9, 15.15])
@@ -137,7 +137,7 @@ def test_ast_executor_selectmany_vector_branch_list():
 
 def test_ast_executor_selectmany_vector_branch_tuple():
     python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
-                     + ' lambda row: (row.int_vector_branch, row.float_vector_branch))')
+                     + ' lambda row: Zip((row.int_vector_branch, row.float_vector_branch)))')
     python_ast = ast.parse(python_source)
     assert ast_executor(python_ast)['0'].tolist() == [-1, 2, 3, 13]
     assert np.allclose(ast_executor(python_ast)['1'].tolist(), [-7.7, 8.8, 9.9, 15.15])
@@ -145,8 +145,8 @@ def test_ast_executor_selectmany_vector_branch_tuple():
 
 def test_ast_executor_selectmany_vector_branch_dict():
     python_source = ("SelectMany(EventDataset('tests/vectors_tree_file.root', 'tree'),"
-                     + " lambda row: {'ints': row.int_vector_branch,"
-                     + " 'floats': row.float_vector_branch})")
+                     + " lambda row: Zip({'ints': row.int_vector_branch,"
+                     + " 'floats': row.float_vector_branch}))")
     python_ast = ast.parse(python_source)
     assert ast_executor(python_ast)['ints'].tolist() == [-1, 2, 3, 13]
     assert np.allclose(ast_executor(python_ast)['floats'].tolist(), [-7.7, 8.8, 9.9, 15.15])

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -103,25 +103,25 @@ def test_conditional():
 
 
 def test_subscripts():
+    assert_identical_source("abs['a']")
     assert_modified_source('abs[0]',
                            ('(abs[abs.fields[0]]'
                             + ' if isinstance(abs, ak.Array) else abs[0])'))
-    assert_modified_source("abs['a']",
-                           ("(abs[abs.fields['a']]"
-                            + " if isinstance(abs, ak.Array) else abs['a'])"))
+    assert_modified_source('abs[abs]',
+                           ('(abs[abs.fields[abs]]'
+                            + ' if isinstance(abs, ak.Array)'
+                            + ' and (isinstance(abs, int) or isinstance(abs, slice))'
+                            + ' else abs[abs])'))
     assert_modified_source('abs[:]',
                            ('(abs[abs.fields[:]]'
                             + ' if isinstance(abs, ak.Array) else abs[:])'))
     assert_modified_source('abs[1:4:2]',
                            ('(abs[abs.fields[1:4:2]]'
                             + ' if isinstance(abs, ak.Array) else abs[1:4:2])'))
-    assert_modified_source('abs[:, :]',
-                           ('(abs[abs.fields[(:, :)]]'
-                            + ' if isinstance(abs, ak.Array) else abs[(:, :)])'))
 
 
 def test_attribute():
-    assert_modified_source('abs.a', "(abs.a if hasattr(abs, 'a') else abs['a'])")
+    assert_modified_source('abs.a', "abs['a']")
 
 
 def test_lambda():

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -57,11 +57,6 @@ def test_builtins():
     assert_identical_source('sum')
 
 
-def test_globals():
-    assert_identical_source('uproot')
-    assert_identical_source('ak')
-
-
 def test_unary_ops():
     assert_equivalent_source('+1')
     assert_identical_source('(-1)')
@@ -108,25 +103,25 @@ def test_conditional():
 
 
 def test_subscripts():
-    assert_modified_source('uproot[0]',
-                           ('(uproot[uproot.fields[0]]'
-                            + ' if isinstance(uproot, ak.Array) else uproot[0])'))
-    assert_modified_source("uproot['a']",
-                           ("(uproot[uproot.fields['a']]"
-                            + " if isinstance(uproot, ak.Array) else uproot['a'])"))
-    assert_modified_source('uproot[:]',
-                           ('(uproot[uproot.fields[:]]'
-                            + ' if isinstance(uproot, ak.Array) else uproot[:])'))
-    assert_modified_source('uproot[1:4:2]',
-                           ('(uproot[uproot.fields[1:4:2]]'
-                            + ' if isinstance(uproot, ak.Array) else uproot[1:4:2])'))
-    assert_modified_source('uproot[:, :]',
-                           ('(uproot[uproot.fields[(:, :)]]'
-                            + ' if isinstance(uproot, ak.Array) else uproot[(:, :)])'))
+    assert_modified_source('abs[0]',
+                           ('(abs[abs.fields[0]]'
+                            + ' if isinstance(abs, ak.Array) else abs[0])'))
+    assert_modified_source("abs['a']",
+                           ("(abs[abs.fields['a']]"
+                            + " if isinstance(abs, ak.Array) else abs['a'])"))
+    assert_modified_source('abs[:]',
+                           ('(abs[abs.fields[:]]'
+                            + ' if isinstance(abs, ak.Array) else abs[:])'))
+    assert_modified_source('abs[1:4:2]',
+                           ('(abs[abs.fields[1:4:2]]'
+                            + ' if isinstance(abs, ak.Array) else abs[1:4:2])'))
+    assert_modified_source('abs[:, :]',
+                           ('(abs[abs.fields[(:, :)]]'
+                            + ' if isinstance(abs, ak.Array) else abs[(:, :)])'))
 
 
 def test_attribute():
-    assert_modified_source('uproot.a', "(uproot.a if hasattr(uproot, 'a') else uproot['a'])")
+    assert_modified_source('abs.a', "(abs.a if hasattr(abs, 'a') else abs['a'])")
 
 
 def test_lambda():
@@ -136,26 +131,26 @@ def test_lambda():
 
 
 def test_call():
-    assert_identical_source('uproot()')
-    assert_identical_source('uproot(1)')
-    assert_identical_source('uproot(1, 2)')
+    assert_identical_source('abs()')
+    assert_identical_source('abs(1)')
+    assert_identical_source('abs(1, 2)')
 
 
 def test_select():
-    assert_modified_source('Select(uproot, lambda row: row)', '(lambda row: row)(uproot)')
+    assert_modified_source('Select(abs, lambda row: row)', '(lambda row: row)(abs)')
 
 
 def test_selectmany():
-    assert_modified_source('SelectMany(uproot, lambda row: row)',
-                           'ak.flatten((lambda row: row)(uproot))')
+    assert_modified_source('SelectMany(abs, lambda row: row)',
+                           'ak.flatten((lambda row: row)(abs))')
 
 
 def test_where():
-    assert_modified_source('Where(uproot, lambda row: True)', '(lambda row: row[True])(uproot)')
+    assert_modified_source('Where(abs, lambda row: True)', '(lambda row: row[True])(abs)')
 
 
 def test_zip():
-    assert_modified_source('Zip(uproot)', 'ak.zip(uproot)')
+    assert_modified_source('Zip(abs)', 'ak.zip(abs)')
 
 
 def test_generate_function_string():


### PR DESCRIPTION
- Simplify handling of Python builtins
- Don't automatically zip lists, tuples, and dicts of columns
- Improve subscript handling
  - Fixes bug that broke accessing branches or dict items by subscript