### PR TITLE
use ak.where for IfExp nodes

### DIFF
--- a/func_adl_uproot/transformer.py
+++ b/func_adl_uproot/transformer.py
@@ -172,7 +172,7 @@ class PythonSourceGeneratorTransformer(ast.NodeTransformer):
         body_rep = self.get_rep(node.body)
         test_rep = self.get_rep(node.test)
         orelse_rep = self.get_rep(node.orelse)
-        node.rep = '(' + body_rep + ' if ' + test_rep + ' else ' + orelse_rep + ')'
+        node.rep = 'ak.where(' + test_rep + ', ' + body_rep + ', ' + orelse_rep + ')'
         return node
 
     def visit_Index(self, node):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -99,7 +99,7 @@ def test_comparison_ops():
 
 
 def test_conditional():
-    assert_identical_source('(1 if True else 0)')
+    assert_modified_source('1 if True else 0', 'ak.where(True, 1, 0)')
 
 
 def test_subscripts():


### PR DESCRIPTION
Allows per-element conditional expressions (i.e., a per-element ternary operator). Up to now, the condition had to be a scalar value.

Resolves #39.