### PR TITLE
ignore extra arguments to `execute_result_async`

### DIFF
--- a/func_adl_uproot/dataset.py
+++ b/func_adl_uproot/dataset.py
@@ -12,5 +12,5 @@ class UprootDataset(EventDataset):
         self._q_ast.args = [unwrap_ast(parse(repr(filenames))), unwrap_ast(parse(repr(treename)))]
 
     @staticmethod
-    async def execute_result_async(ast):
+    async def execute_result_async(ast, *args, **kwargs):
         return ast_executor(ast)


### PR DESCRIPTION
fix bug caused by https://github.com/iris-hep/func_adl/pull/70