### PR TITLE
Filter out branches that can't be interpreted by Uproot/Awkward

### DIFF
--- a/func_adl_uproot/transformer.py
+++ b/func_adl_uproot/transformer.py
@@ -438,7 +438,9 @@ class PythonSourceGeneratorTransformer(ast.NodeTransformer):
                 + "(logging.getLogger(__name__).info('Using treename='"
                 + ' + repr(tree_name_to_use)),'
                 + ' uproot.dask({input_file: tree_name_to_use'
-                + ' for input_file in input_files}, filter_branch=' + branch_filter_name + '))[1])'
+                + ' for input_file in input_files}, filter_branch='
+                + branch_filter_name
+                + '))[1])'
                 + '('
                 + source_rep
                 + ', '

--- a/func_adl_uproot/transformer.py
+++ b/func_adl_uproot/transformer.py
@@ -438,7 +438,7 @@ class PythonSourceGeneratorTransformer(ast.NodeTransformer):
                 + "(logging.getLogger(__name__).info('Using treename='"
                 + ' + repr(tree_name_to_use)),'
                 + ' uproot.dask({input_file: tree_name_to_use'
-                + ' for input_file in input_files}, filter_branch=' + branch_filter_name+ '))[1])'
+                + ' for input_file in input_files}, filter_branch=' + branch_filter_name + '))[1])'
                 + '('
                 + source_rep
                 + ', '

--- a/func_adl_uproot/transformer.py
+++ b/func_adl_uproot/transformer.py
@@ -8,6 +8,7 @@ allowed_modules = ['np']
 
 input_filenames_argument_name = 'input_filenames'
 tree_name_argument_name = 'tree_name'
+branch_filter_name = '_remove_not_interpretable'
 
 unary_op_dict = {ast.UAdd: '+', ast.USub: '-', ast.Invert: '~'}
 
@@ -437,7 +438,7 @@ class PythonSourceGeneratorTransformer(ast.NodeTransformer):
                 + "(logging.getLogger(__name__).info('Using treename='"
                 + ' + repr(tree_name_to_use)),'
                 + ' uproot.dask({input_file: tree_name_to_use'
-                + ' for input_file in input_files}))[1])'
+                + ' for input_file in input_files}, filter_branch=' + branch_filter_name+ '))[1])'
                 + '('
                 + source_rep
                 + ', '

--- a/func_adl_uproot/translation.py
+++ b/func_adl_uproot/translation.py
@@ -5,11 +5,13 @@ import qastle
 from .transformer import PythonSourceGeneratorTransformer
 from .transformer import branch_filter_name, input_filenames_argument_name, tree_name_argument_name
 
-# Adapted from https://github.com/CoffeaTeam/coffea/blob/e2cd5e291e90314b619a40a1ecd2649f1b2de00f/src/coffea/util.py#L217-L248
+# Adapted from https://github.com/CoffeaTeam/coffea/blob/v2024.4.0/src/coffea/util.py#L217-L248
 remove_not_interpretable_source = '''    def ''' + branch_filter_name + '''(branch):
         if isinstance(branch.interpretation, uproot.interpretation.identify.uproot.AsGrouped):
             for name, interpretation in branch.interpretation.subbranches.items():
-                if isinstance(interpretation, uproot.interpretation.identify.UnknownInterpretation):
+                if isinstance(
+                        interpretation, uproot.interpretation.identify.UnknownInterpretation
+                    ):
                     logging.getLogger(__name__).warning(
                         f"Skipping {branch.name} as it is not interpretable by Uproot"
                     )

--- a/func_adl_uproot/translation.py
+++ b/func_adl_uproot/translation.py
@@ -6,7 +6,10 @@ from .transformer import PythonSourceGeneratorTransformer
 from .transformer import branch_filter_name, input_filenames_argument_name, tree_name_argument_name
 
 # Adapted from https://github.com/CoffeaTeam/coffea/blob/v2024.4.0/src/coffea/util.py#L217-L248
-remove_not_interpretable_source = '''    def ''' + branch_filter_name + '''(branch):
+remove_not_interpretable_source = (
+    '    def '
+    + branch_filter_name
+    + '''(branch):
         if isinstance(branch.interpretation, uproot.interpretation.identify.uproot.AsGrouped):
             for name, interpretation in branch.interpretation.subbranches.items():
                 if isinstance(
@@ -32,6 +35,7 @@ remove_not_interpretable_source = '''    def ''' + branch_filter_name + '''(bran
             return True
 
 '''
+)
 
 
 def python_ast_to_python_source(python_ast):


### PR DESCRIPTION
Fix for working around uninterpretable branches thanks to a filter function from [coffea](https://github.com/CoffeaTeam/coffea).

Resolves #82.